### PR TITLE
Fix AllNftInfo msg

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -134,7 +134,9 @@ impl Configuration {
     }
 
     pub fn get_owner(store: &dyn Storage) -> StdResult<Addr> {
-        if Item::<'_, Addr>::new("always_owner").load(store).is_ok() {}
+        if let Ok(owner) = Item::<'_, Addr>::new("always_owner").load(store) {
+            return Ok(owner);
+        }
 
         Err(StdError::GenericErr {
             msg: "Unable to load always_owner Addr".to_string(),


### PR DESCRIPTION
Fixes #1. The implementation was not doing anything after retrieving the `always_owner` address, and always falling through to the error return.
